### PR TITLE
Fix type inference for confitional function references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,12 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e035019ccf76253261e8ba408182d2d4de6acc4dac78c41b2e5d645df2301205"
-
-[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +485,6 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 name = "nasin"
 version = "0.1.0"
 dependencies = [
- "cfor",
  "clap",
  "cranelift_shim",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = ["cranelift-shim", "tree-sitter-nasin"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfor = "1.1.0"
 clap = { version = "4.4.18", features = ["derive"] }
 cranelift_shim = { path = "cranelift-shim" }
 derivative = "2.2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,14 +24,21 @@ impl fmt::Display for DisplayError<'_> {
 
         let line = err.loc.start_line;
         let col = err.loc.start_col;
-        writeln!(f, "{}:{line}:{col}", src.path.display())?;
+        writeln!(
+            f,
+            "{}:{line}:{col} - error: {}",
+            src.path.display(),
+            err.detail
+        )?;
 
         let num = format!("{line}");
         let line_content = src.content().line(line).expect("line should be valid");
-        writeln!(f, "{} |", " ".repeat(num.len()))?;
-        writeln!(f, "{num} | {line_content}",)?;
-        writeln!(f, "{} | {}^", " ".repeat(num.len()), " ".repeat(col - 1))?;
-        writeln!(f, "error: {}", err.detail)?;
+        let leading_spaces = line_content
+            .chars()
+            .take_while(|c| c.len_utf8() == 1 && c.is_whitespace())
+            .count();
+        writeln!(f, "{num} | {}", &line_content[leading_spaces..])?;
+        writeln!(f, "{}^", " ".repeat(num.len() + col - leading_spaces + 2))?;
 
         Ok(())
     }

--- a/src/parser/expr_parser.rs
+++ b/src/parser/expr_parser.rs
@@ -104,10 +104,12 @@ impl<'a, 't> ExprParser<'a, 't> {
                 ValueRef::new(ValueRefBody::Number(number.to_string()), loc)
             }
             "string_lit" => {
-                let string =
-                    utils::decode_string_lit(node.required_field("content").get_text(
+                let string = match node.field("content") {
+                    Some(content) => utils::decode_string_lit(content.get_text(
                         &self.module.ctx.source(self.module.src_idx).content().text,
-                    ));
+                    )),
+                    None => "".to_string(),
+                };
                 let v = self.add_instr_with_result(b::Instr::new(
                     b::InstrBody::CreateString(string),
                     loc,

--- a/src/typecheck/constraints.rs
+++ b/src/typecheck/constraints.rs
@@ -20,7 +20,8 @@ pub enum Constraint {
     IsProperty(b::ValueIdx, String),
     Members(SortedMap<String, b::ValueIdx>),
     HasProperty(String, b::ValueIdx),
-    Func(Vec<usize>, usize),
+    GetFunc(usize, usize),
+    Func(Vec<b::ValueIdx>, b::ValueIdx),
 }
 impl Constraint {
     pub fn priority(&self) -> ConstraintPriority {
@@ -32,6 +33,7 @@ impl Constraint {
             | Self::ArrayElemPtr(..)
             | Self::ReturnOf(..)
             | Self::ParameterOf(..)
+            | Self::GetFunc(..)
             | Self::IsProperty(..) => ConstraintPriority::DerivedDefinedType,
             Self::Members(..) | Self::HasProperty(..) | Self::Func(..) => {
                 ConstraintPriority::DerivedInferredType

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -4,12 +4,11 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::mem;
 
-use cfor::cfor;
 use derive_new::new;
 use itertools::{enumerate, izip, Itertools};
 
 use self::constraints::Constraint;
-use crate::utils::SortedMap;
+use crate::utils::{cfor, SortedMap};
 use crate::{bytecode as b, context, errors, utils};
 
 #[derive(Debug, Clone, new)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -34,3 +34,25 @@ macro_rules! unwrap {
     };
 }
 pub(crate) use unwrap;
+
+macro_rules! cfor {
+    ($( $decl:stmt ),* $(,)? ; $cond:expr ; $( $step:expr ),* $(,)? ; $body:block) => {
+        {
+            let mut cfor_should_step = false;
+            $( $decl );*
+            loop {
+                if cfor_should_step {
+                    $( $step );*
+                } else {
+                    cfor_should_step = true;
+                }
+                if !$cond { break; }
+                $body
+            }
+        }
+    };
+    ($( $decl:stmt ),* $(,)? ; ; $( $step:expr ),* $(,)? ; $body:block) => {
+        cfor!($( $decl ),*; true; $( $step ),*; $body)
+    };
+}
+pub(crate) use cfor;

--- a/tests/_test.list.bi
+++ b/tests/_test.list.bi
@@ -104,9 +104,12 @@ Hi method
 :b shell 93
 ./bin/nasin b tests/func_as_value.nsn -o tests/out/func_as_value && ./tests/out/func_as_value
 :i returncode 0
-:b stdout 50
+:b stdout 86
 Compiled program to tests/out/func_as_value
-Hello
+PrintA
+Hello direct
+PrintA
+Hello indirect
 
 :b stderr 0
 

--- a/tests/func_as_value.nsn
+++ b/tests/func_as_value.nsn
@@ -1,8 +1,15 @@
 main =
-    call(print2)
+    let f = if true then print_a else print_b
+    let _ = f("Hello direct")
+    call(f)
 
 call(f): bool =
-    f("Hello")
+    f("Hello indirect")
 
-print2(msg) =
+print_a(msg) =
+    let _ = print("PrintA")
+    print(msg)
+
+print_b(msg) =
+    let _ = print("PrintB")
     print(msg)


### PR DESCRIPTION
Type inference would break if the function reference was behind a conditional block.
Also, I've cleaned up the error messages so it's more readable, implemented comments and empty strings in the grammar (kinda wild they were not implemented yet) and implemented cfor myself instead of using the crate because their implementation uses two loops and I don't like that